### PR TITLE
feat: add the abbr module

### DIFF
--- a/modules/abbr/assets/hb/modules/revision-abbr/js/index.ts
+++ b/modules/abbr/assets/hb/modules/revision-abbr/js/index.ts
@@ -1,0 +1,16 @@
+import Tooltip from "js/bootstrap/src/tooltip"
+
+(() => {
+  document.querySelectorAll('abbr').forEach(element => {
+    let tooltip
+    element.addEventListener('mouseenter', () => {
+      tooltip = Tooltip.getOrCreateInstance(element, {
+        placement: 'bottom'
+      })
+      tooltip.show()
+    })
+    element.addEventListener('mouseout', () => {
+      tooltip && tooltip.dispose()
+    })
+  });
+})()

--- a/modules/abbr/assets/hb/modules/revision-abbr/scss/index.scss
+++ b/modules/abbr/assets/hb/modules/revision-abbr/scss/index.scss
@@ -1,0 +1,7 @@
+/*! purgecss start ignore */
+
+abbr[data-bs-original-title] {
+  @extend abbr[title];
+}
+
+/*! purgecss end ignore */

--- a/modules/abbr/go.mod
+++ b/modules/abbr/go.mod
@@ -1,0 +1,3 @@
+module github.com/hbstack/bs-tooltip/modules/abbr
+
+go 1.19

--- a/modules/abbr/hugo.toml
+++ b/modules/abbr/hugo.toml
@@ -1,0 +1,2 @@
+[[module.imports]]
+path = "github.com/hbstack/bs-tooltip"


### PR DESCRIPTION
This module `github.com/hbstack/bs-tooltip/modules/abbr` replaces built-in tooltip with Bootstrap tooltip for `<abbr>` elements.